### PR TITLE
Introduce NanoAddress type

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ For more details about websocket, see [Websocket](#websocket).
   - [Uptime](#uptime)
   - [Version](#version)
 - [Rpc](#rpc)
+- [Datatypes](#datatypes)
+  - [NanoTarget](#nanotarget)
 
 ## Wallet
 
@@ -199,7 +201,8 @@ const wallet = nona.wallet(privateKey);
 open(representative: NanoTarget): Promise<string>
 ```
 
-Opens the account with the provided representative.  
+Opens the account with the provided representative represented as a [NanoTarget](#nanotarget).
+
 The first transaction of an account is crafted in a [slightly different way](https://docs.nano.org/integration-guides/key-management/#first-receive-transaction). To open an account, you must have sent some funds to it from another account.  
 Returns the hash of the transaction.
 
@@ -214,7 +217,7 @@ await wallet.open(representative);
 send(target: NanoTarget, amount: number | string): Promise<string>
 ```
 
-Sends a transaction to the specified address.  
+Sends a transaction to the specified [target](#nanotarget).
 The amount is in nano unit.  
 Returns the hash of the transaction.
 
@@ -937,6 +940,12 @@ const info = await nona.rpc('account_info', {
   account: 'nano_13e2ue...',
 });
 ```
+
+## Datatypes
+
+### NanoTarget
+
+A NanoTarget is either a valid address (e.g. `nano_1rece...`) or a resolveable username registered with the [Nano Name Service](nano.to) (e.g. `@nona-lib`). Nonalib automatically resolves these usernames to valid adresses for you.
 
 ## Handling Errors
 

--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ We encourage the community to contribute to the development and testing of Nona 
 
 #### Nano.to
 
-- [ ] Integrate [Nano name service](https://github.com/fwd/nano-to) (in progress)
+- [x] Integrate [Nano Name Service](https://github.com/fwd/nano-to)
 - [ ] Integrate [rpc.nano.to](https://rpc.nano.to/) commands
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -177,8 +177,13 @@ For more details about websocket, see [Websocket](#websocket).
   - [Uptime](#uptime)
   - [Version](#version)
 - [Rpc](#rpc)
-- [Datatypes](#datatypes)
-  - [NanoTarget](#nanotarget)
+- [Name Service](#name-service)
+  - [Resolve Username](#resolve-username)
+  - [Resolve Target](#resolve-target)
+- [Datatypes](#datatypess)
+  - [Nano Address](#nano-address)
+  - [Nano Username](#nano-username)
+  - [Nano Target](#nano-target)
 
 ## Wallet
 
@@ -941,11 +946,66 @@ const info = await nona.rpc('account_info', {
 });
 ```
 
+## Name Service
+
+### Resolve Username
+
+```typescript
+resolveUsername(username: NanoUsername): Promise<NanoAddress>
+```
+
+Resolves a username registered with the [Nano Name Service](https://nano.to) to the registed [NanoAddress](#nano-address)
+
+```typescript
+const username = '@nona-lib';
+const address = resolveUsername(username): Promise<NanoAddress>
+```
+
+### Resolve Target
+
+```typescript
+resolveTarget(target: NanoTarget): Promise<NanoAddress>
+```
+
+Takes in a [NanoTarget](#nano-target) to potentially resolve. It checks if the target is a valid [NanoAddress](#nano-address) or a [NanoUsername](#nano-username). In the case a [NanoUsername](#nano-username) is passed to the method, it is [automatically resolved](#resolve-username)
+
+```typescript
+const target = '@nona-lib';
+const address = resolveTarget(target): Promise<NanoAddress>
+```
+
+```typescript
+const target = 'nano_1rece';
+const address = resolveTarget(target): Promise<NanoAddress>
+```
+
 ## Datatypes
 
-### NanoTarget
+### Nano Address
 
-A NanoTarget is either a valid address (e.g. `nano_1rece...`) or a resolveable username registered with the [Nano Name Service](nano.to) (e.g. `@nona-lib`). Nonalib automatically resolves these usernames to valid adresses for you.
+A valid Nano address according to the [offical docs](https://docs.nano.org/integration-guides/the-basics/#account-public-address):
+
+```
+nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs
+```
+
+Its validity is checked with the [nanocurrency-js](https://github.com/marvinroger/nanocurrency-js/tree/master/packages/nanocurrency) package.
+
+
+### Nano Username
+
+A Nano username in the form of `@name`:
+
+```
+@nona-lib
+```
+
+This username is resolved at runtime with the [Nano Name Service](https://nano.to).
+
+
+### Nano Target
+
+A NanoTarget is either a valid [address](#nano-address) (e.g. `nano_1rece...`) or a resolveable username registered with the [Nano Name Service](https://nano.to) (e.g. `@nona-lib`). Nonalib automatically resolves these usernames to valid adresses for you.
 
 ## Handling Errors
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const wallet = nona.wallet(privateKey);
 ### Open
 
 ```typescript
-open(representative: string): Promise<string>
+open(representative: NanoTarget): Promise<string>
 ```
 
 Opens the account with the provided representative.  
@@ -211,7 +211,7 @@ await wallet.open(representative);
 ### Send
 
 ```typescript
-send(address: NanoAddress, amount: number | string): Promise<string>
+send(target: NanoTarget, amount: number | string): Promise<string>
 ```
 
 Sends a transaction to the specified address.  
@@ -474,7 +474,7 @@ export interface ConfirmationFilter {
   /** List of block subtypes to filter the confirmation blocks. */
   subtype?: string[];
   /** Account addresses that received the transaction. */
-  to?: string[];
+  to?: NanoAddress[];
 }
 ````
 
@@ -515,7 +515,7 @@ export interface AccountHistoryParams {
   /** Reverse order */
   reverse?: boolean;
   /** Results will be filtered to only show sends/receives connected to the provided account(s). */
-  accounts?: string[];
+  accounts?: NanoAddress[];
   /**
    * if set to true instead of the default false, returns all blocks history and output all parameters of the block itself.
    */
@@ -658,11 +658,11 @@ interface WebSocketConfirmationParams {
 
 interface ConfirmationFilter {
   /** List of account addresses to filter the confirmation blocks. */
-  accounts?: string[];
+  accounts?: NanoAddress[];
   /** List of block subtypes to filter the confirmation blocks. */
   subtype?: string[];
   /** Account addresses that received the transaction. */
-  to?: string[];
+  to?: NanoAddress[];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -950,9 +950,9 @@ const info = await nona.rpc('account_info', {
 
 You can access to the `nameService` object with the following code:
 
-\```typescript
+```typescript
 const nameService = nona.nameService;
-\```
+```
 
 ### Resolve Username
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ const wallet = nona.wallet(privateKey);
 open(representative: NanoTarget): Promise<string>
 ```
 
-Opens the account with the provided representative represented as a [NanoTarget](#nanotarget).
+Opens the account with the provided representative represented as a [NanoTarget](#nano-target) string.
 
 The first transaction of an account is crafted in a [slightly different way](https://docs.nano.org/integration-guides/key-management/#first-receive-transaction). To open an account, you must have sent some funds to it from another account.  
 Returns the hash of the transaction.
@@ -222,7 +222,7 @@ await wallet.open(representative);
 send(target: NanoTarget, amount: number | string): Promise<string>
 ```
 
-Sends a transaction to the specified [target](#nanotarget).
+Sends a transaction to the specified [target](#nano-target).
 The amount is in nano unit.  
 Returns the hash of the transaction.
 
@@ -948,6 +948,12 @@ const info = await nona.rpc('account_info', {
 
 ## Name Service
 
+You can access to the `nameService` object with the following code:
+
+\```typescript
+const nameService = nona.nameService;
+\```
+
 ### Resolve Username
 
 ```typescript
@@ -958,7 +964,7 @@ Resolves a username registered with the [Nano Name Service](https://nano.to) to 
 
 ```typescript
 const username = '@nona-lib';
-const address = resolveUsername(username): Promise<NanoAddress>
+const address = await nona.nameService.resolveUsername(username);
 ```
 
 ### Resolve Target
@@ -971,12 +977,12 @@ Takes in a [NanoTarget](#nano-target) to potentially resolve. It checks if the t
 
 ```typescript
 const target = '@nona-lib';
-const address = resolveTarget(target): Promise<NanoAddress>
+const address = await nona.nameService.resolveTarget(target);
 ```
 
 ```typescript
-const target = 'nano_1rece';
-const address = resolveTarget(target): Promise<NanoAddress>
+const target = 'nano_1rece...';
+const address = await nona.nameService.resolveTarget(target);
 ```
 
 ## Datatypes

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ await wallet.open(representative);
 ### Send
 
 ```typescript
-send(address: string, amount: number | string): Promise<string>
+send(address: NanoAddress, amount: number | string): Promise<string>
 ```
 
 Sends a transaction to the specified address.  

--- a/lib/modules/account/account-interface.ts
+++ b/lib/modules/account/account-interface.ts
@@ -1,3 +1,4 @@
+import { NanoAddress } from '../../shared/utils/address';
 import {
   ConfirmationFilter,
   WebSocketConfirmationParams,
@@ -68,7 +69,7 @@ export interface AccountHistoryParams {
   /** Reverse order */
   reverse?: boolean;
   /** Results will be filtered to only show sends/receives connected to the provided account(s). */
-  accounts?: string[];
+  accounts?: NanoAddress[];
   /**
    * if set to true instead of the default false, returns all blocks history and output all parameters of the block itself.
    */

--- a/lib/modules/account/account-shemas.ts
+++ b/lib/modules/account/account-shemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { UnitService } from '../../services/unit/unit-service';
+import { zNanoAddress } from '../../shared/utils/address';
 
 export const ReceivableValues = z.object({
   blocks: z.record(z.string()).or(z.string()),
@@ -36,7 +37,7 @@ export type AccountInfo = z.infer<typeof AccountInfo>;
 
 export const AccountInfoRepresentative = AccountInfo.extend({
   /** Account address of the currently set representative for this account. */
-  representative: z.string(),
+  representative: zNanoAddress(),
 });
 export type AccountInfoRepresentative = z.infer<typeof AccountInfoRepresentative>;
 
@@ -69,7 +70,7 @@ export type AccountHistoryPagination = z.infer<typeof AccountHistoryPagination>;
 
 export const AccountHistoryBlock = z.object({
   /** Account address of the block. */
-  account: z.string(),
+  account: zNanoAddress(),
   /** Amount of the block in nano unit */
   amount: z.string().transform((amount) => UnitService.rawToNanoString(amount)),
   /** Type of block. */
@@ -85,7 +86,7 @@ export type AccountHistoryBlock = z.infer<typeof AccountHistoryBlock>;
 
 export const AccountHistoryRawBlock = AccountHistoryBlock.extend({
   /** Account address of the block. Not present if it's a 'receive' or 'send' block. */
-  account: z.string().optional(),
+  account: zNanoAddress().optional(),
   /** Amount of the block in raw unit. Not present if it's a 'receive' or 'send' block. */
   amount: z.string().optional(),
   /** Account address of the representative for this account. */

--- a/lib/modules/account/account.ts
+++ b/lib/modules/account/account.ts
@@ -28,9 +28,10 @@ import {
   ReceivableHashes,
   ReceivableValues,
 } from './account-shemas';
+import { NanoAddress } from '../../shared/utils/address';
 
 export class Account extends RpcConsummer {
-  constructor(public address: string, private websocket: NonaWebSocket, rpc: Rpc) {
+  constructor(public address: NanoAddress, private websocket: NonaWebSocket, rpc: Rpc) {
     super(rpc);
   }
 

--- a/lib/modules/blocks/blocks-interface.ts
+++ b/lib/modules/blocks/blocks-interface.ts
@@ -1,6 +1,8 @@
+import { NanoAddress } from '../../shared/utils/address';
+
 export interface CreateBlockParams {
   /** The account the block is being created for. */
-  account: string;
+  account: NanoAddress;
   /** Final balance for account after block creation. In raw unit */
   balance: string;
   /** Private key of the account */
@@ -8,7 +10,7 @@ export interface CreateBlockParams {
   /** The block hash of the previous block on this account's block chain ("0" for first block). */
   previous: string;
   /** The representative account for the account. */
-  representative: string;
+  representative: NanoAddress;
   /** If the block is sending funds, set link to the public key of the destination account. If it is receiving funds, set link to the hash of the block to receive. If the block has no balance change but is updating representative only, set link to 0. */
   link: string;
 }

--- a/lib/modules/blocks/blocks-schema.ts
+++ b/lib/modules/blocks/blocks-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { zNanoAddress } from '../../shared/utils/address';
 
 export const BlockCount = z.object({
   /** The total number of blocks in the ledger. This includes all send, receive, open, and change blocks. */
@@ -14,12 +15,12 @@ export const Block = z.object({
   hash: z.string(),
   block: z.object({
     type: z.string(),
-    account: z.string(),
+    account: zNanoAddress(),
     previous: z.string(),
-    representative: z.string(),
+    representative: zNanoAddress(),
     balance: z.string(),
     link: z.string(),
-    link_as_account: z.string(),
+    link_as_account: zNanoAddress(),
     signature: z.string(),
     work: z.string(),
   }),
@@ -33,7 +34,7 @@ export type BlockProcess = z.infer<typeof BlockProcess>;
 
 // TODO: Comment each fields
 export const BlockInfo = z.object({
-  block_account: z.string(),
+  block_account: zNanoAddress(),
   amount: z.string(),
   balance: z.string(),
   height: z.string(),
@@ -42,12 +43,12 @@ export const BlockInfo = z.object({
   confirmed: z.string(),
   contents: z.object({
     type: z.string(),
-    account: z.string(),
+    account: zNanoAddress(),
     previous: z.string(),
     representative: z.string(),
     balance: z.string(),
     link: z.string(),
-    link_as_account: z.string(),
+    link_as_account: zNanoAddress(),
     signature: z.string(),
     work: z.string(),
   }),

--- a/lib/modules/key/key-interface.ts
+++ b/lib/modules/key/key-interface.ts
@@ -1,3 +1,5 @@
+import { NanoAddress } from '../../shared/utils/address';
+
 // Must change the key names to avoid 'private' and 'public' reserved word error
 export interface AccountKeys {
   /** Private key of the account */
@@ -5,12 +7,12 @@ export interface AccountKeys {
   /** Public key of the account */
   publicKey: string;
   /** Address of the account */
-  address: string;
+  address: NanoAddress;
 }
 
 export interface ExpandedKeys {
   /** Public key of the account */
   publicKey: string;
   /** Address of the account */
-  address: string;
+  address: NanoAddress;
 }

--- a/lib/modules/wallet/wallet.ts
+++ b/lib/modules/wallet/wallet.ts
@@ -199,7 +199,9 @@ export class Wallet extends Account {
    * @param representative The new representative to set.
    * @returns A promise that resolves to the hash of the changed block.
    */
-  public async change(representative: NanoAddress): Promise<string> {
+  public async change(representative: NanoTarget): Promise<string> {
+    representative = await this.nameService.resolveTarget(representative);
+
     const info = await this.info({
       raw: true,
     });

--- a/lib/modules/wallet/wallet.ts
+++ b/lib/modules/wallet/wallet.ts
@@ -4,6 +4,7 @@ import { KeyService } from '../../services/hash/key-service';
 import { Rpc } from '../../services/rpc/rpc';
 import { UnitService } from '../../services/unit/unit-service';
 import { NonaUserError } from '../../shared/errors/user-error';
+import { NanoAddress } from '../../shared/utils/address';
 import { NonaBigNumber } from '../../shared/utils/big-number';
 import { Account } from '../account/account';
 import { Blocks } from '../blocks/blocks';
@@ -16,7 +17,7 @@ import { WalletListAndReceiveParams } from './wallet-interface';
  */
 export class Wallet extends Account {
   public publicKey: string;
-  public address: string;
+  public address: NanoAddress;
 
   constructor(
     private privateKey: string,
@@ -41,7 +42,7 @@ export class Wallet extends Account {
    * @param representative The representative to open the wallet with.
    * @returns A promise that resolves to the hash of the opened block.
    */
-  public async open(representative: string): Promise<string> {
+  public async open(representative: NanoAddress): Promise<string> {
     // Highest hash
     const lastHashes = await this.receivable({ count: 1, sort: true });
     if (Object.keys(lastHashes).length === 0) {
@@ -122,7 +123,7 @@ export class Wallet extends Account {
    * @param amount The amount to send in nano unit.
    * @returns A promise that resolves to the hash of the sent block.
    */
-  public async send(address: string, amount: number | string): Promise<string> {
+  public async send(address: NanoAddress, amount: number | string): Promise<string> {
     // Convert nano amout to raw amount
     const rawAmount = UnitService.nanoToRaw(amount);
     if (rawAmount.isLessThanOrEqualTo(0) || rawAmount.isNaN()) {
@@ -192,7 +193,7 @@ export class Wallet extends Account {
    * @param representative The new representative to set.
    * @returns A promise that resolves to the hash of the changed block.
    */
-  public async change(representative: string): Promise<string> {
+  public async change(representative: NanoAddress): Promise<string> {
     const info = await this.info({
       raw: true,
     });

--- a/lib/modules/websocket/confirmation/websocket-confirmation-interface.ts
+++ b/lib/modules/websocket/confirmation/websocket-confirmation-interface.ts
@@ -1,3 +1,5 @@
+import { NanoAddress } from '../../../shared/utils/address';
+
 export interface WebSocketConfirmationParams {
   /**
    * A function that will be called each time a transaction is received.
@@ -20,8 +22,8 @@ export interface WebSocketConfirmationParams {
 }
 
 export interface WebSocketUpdateConfirmationParams {
-  accountsAdd?: string[];
-  accountsDel?: string[];
+  accountsAdd?: NanoAddress[];
+  accountsDel?: NanoAddress[];
 }
 
 /**
@@ -29,7 +31,7 @@ export interface WebSocketUpdateConfirmationParams {
  */
 export interface ConfirmationBlock {
   /** Account address involved in the transaction. */
-  account: string;
+  account: NanoAddress;
   /** Amount transferred in the transaction, in nano unit. */
   amount: string;
   /** Unique hash of the block. This serves as an identifier for the block on the network. */
@@ -38,17 +40,17 @@ export interface ConfirmationBlock {
   confirmationType: string;
   block: {
     /** The account address that owns this block. */
-    account: string;
+    account: NanoAddress;
     /** Hash of the previous block in the account's chain, linking this block to its predecessor. 0 if open block. */
     previous: string;
     /** Representative of the account. */
-    representative: string;
+    representative: NanoAddress;
     /** Resulting balance of the account in nano unit. */
     balance: string;
     /** In a send block, public key of the destination account; in a receive block, the hash of the send block being received; in a change block, 0. */
     link: string;
     /** In a send block, account address of the link field. */
-    linkAsAccount: string;
+    linkAsAccount: NanoAddress;
     /** Digital signature of the block. */
     signature: string;
     /** Work field represents the Proof of Work for the block. */
@@ -60,9 +62,9 @@ export interface ConfirmationBlock {
 
 export interface ConfirmationFilter {
   /** List of account addresses to filter the confirmation blocks. */
-  accounts?: string[];
+  accounts?: NanoAddress[];
   /** List of block subtypes to filter the confirmation blocks. */
   subtype?: string[];
   /** Account addresses that received the transaction. */
-  to?: string[];
+  to?: NanoAddress[];
 }

--- a/lib/modules/websocket/confirmation/websocket-confirmation-schema.ts
+++ b/lib/modules/websocket/confirmation/websocket-confirmation-schema.ts
@@ -1,18 +1,19 @@
 import { z } from 'zod';
+import { zNanoAddress } from '../../../shared/utils/address';
 
 export const WebSocketConfirmationMessage = z.object({
-  account: z.string(),
+  account: zNanoAddress(),
   amount: z.string(),
   hash: z.string(),
   confirmation_type: z.string(),
   block: z.object({
     type: z.string(),
-    account: z.string(),
+    account: zNanoAddress(),
     previous: z.string(),
-    representative: z.string(),
+    representative: zNanoAddress(),
     balance: z.string(),
     link: z.string(),
-    link_as_account: z.string(),
+    link_as_account: zNanoAddress(),
     signature: z.string(),
     work: z.string(),
     subtype: z.string(),

--- a/lib/modules/websocket/confirmation/websocket-confirmation.ts
+++ b/lib/modules/websocket/confirmation/websocket-confirmation.ts
@@ -1,5 +1,6 @@
 import { filter, finalize, map, Observable, Subscription } from 'rxjs';
 
+import { NanoAddress } from '../../../shared/utils/address';
 import { WebSocketManager } from '../manager/websocket-manager';
 import { WebSocketConfirmationHelper } from './websocket-confirmation-helper';
 import {
@@ -11,7 +12,7 @@ import {
 
 // TODO: Need to refactor this file
 export class WebSocketConfirmation {
-  private accountListened = new Map<string, number>();
+  private accountListened = new Map<NanoAddress, number>();
   private observable: Observable<unknown>;
   private subscriptionCount = 0;
   private subscriptionToAll = 0;
@@ -43,10 +44,10 @@ export class WebSocketConfirmation {
       });
   }
 
-  private getAccountsToListen(confirmationFilter?: ConfirmationFilter): string[] | undefined {
+  private getAccountsToListen(confirmationFilter?: ConfirmationFilter): NanoAddress[] | undefined {
     if (!confirmationFilter) return undefined;
     const { accounts, to } = confirmationFilter;
-    const accountsToListen = [];
+    const accountsToListen: NanoAddress[] = [];
 
     let filtered = false;
     if (accounts) {
@@ -63,7 +64,7 @@ export class WebSocketConfirmation {
     return uniqueAccounts;
   }
 
-  private addSubscription(accounts?: string[]): void {
+  private addSubscription(accounts?: NanoAddress[]): void {
     if (this.subscriptionCount === 0) {
       this.subscribeWebSocket(accounts);
     }
@@ -85,7 +86,7 @@ export class WebSocketConfirmation {
     this.subscriptionCount += 1;
   }
 
-  private removeSubscription(accounts?: string[]): void {
+  private removeSubscription(accounts?: NanoAddress[]): void {
     if (accounts) {
       const accountsRemoved = this.removeAccountsFromListened(accounts);
       if (this.subscriptionToAll === 0 && this.subscriptionCount > 1) {
@@ -104,8 +105,8 @@ export class WebSocketConfirmation {
     }
   }
 
-  private addAccountsToListened(accounts: string[]): string[] {
-    const addedAccount: string[] = [];
+  private addAccountsToListened(accounts: NanoAddress[]): NanoAddress[] {
+    const addedAccount: NanoAddress[] = [];
 
     for (const account of accounts) {
       const accountMap = this.accountListened.get(account);
@@ -120,8 +121,8 @@ export class WebSocketConfirmation {
     return addedAccount;
   }
 
-  private removeAccountsFromListened(accounts: string[]): string[] {
-    const accountRemoved: string[] = [];
+  private removeAccountsFromListened(accounts: NanoAddress[]): NanoAddress[] {
+    const accountRemoved: NanoAddress[] = [];
 
     for (const account of accounts) {
       const accountMap = this.accountListened.get(account);
@@ -138,7 +139,7 @@ export class WebSocketConfirmation {
     return accountRemoved;
   }
 
-  private subscribeWebSocket(accounts?: string[]): void {
+  private subscribeWebSocket(accounts?: NanoAddress[]): void {
     this.webSocketManager.subscribeTopic({
       topic: 'confirmation',
       options: accounts

--- a/lib/nona.ts
+++ b/lib/nona.ts
@@ -1,4 +1,3 @@
-import { Rpc } from './services/rpc/rpc';
 import { Account } from './modules/account/account';
 import { Blocks } from './modules/blocks/blocks';
 import { Key } from './modules/key/key';
@@ -6,6 +5,8 @@ import { Node } from './modules/node/node';
 import { NonaParams } from './modules/nona/nona-interface';
 import { Wallet } from './modules/wallet/wallet';
 import { NonaWebSocket } from './modules/websocket/websocket';
+import { Rpc } from './services/rpc/rpc';
+import { NanoAddress } from './shared/utils/address';
 
 export class Nona {
   private remoteProcedureCall: Rpc;
@@ -28,7 +29,7 @@ export class Nona {
     this.key = new Key();
   }
 
-  public account(address: string): Account {
+  public account(address: NanoAddress): Account {
     return new Account(address, this.ws, this.remoteProcedureCall);
   }
 

--- a/lib/nona.ts
+++ b/lib/nona.ts
@@ -5,12 +5,14 @@ import { Node } from './modules/node/node';
 import { NonaParams } from './modules/nona/nona-interface';
 import { Wallet } from './modules/wallet/wallet';
 import { NonaWebSocket } from './modules/websocket/websocket';
+import { NameService } from './services/name/name-service';
 import { Rpc } from './services/rpc/rpc';
 import { NanoAddress } from './shared/utils/address';
 
 export class Nona {
   private remoteProcedureCall: Rpc;
 
+  public nameService: NameService;
   public ws: NonaWebSocket;
   public blocks: Blocks;
   public key: Key;
@@ -23,6 +25,7 @@ export class Nona {
     websocketUrl = 'ws://localhost:7078',
   }: NonaParams = {}) {
     this.remoteProcedureCall = new Rpc({ url });
+    this.nameService = new NameService();
     this.ws = new NonaWebSocket({ url: websocketUrl });
     this.blocks = new Blocks(this.remoteProcedureCall);
     this.node = new Node(this.remoteProcedureCall);
@@ -34,7 +37,7 @@ export class Nona {
   }
 
   public wallet(privateKey: string): Wallet {
-    return new Wallet(privateKey, this.blocks, this.remoteProcedureCall, this.ws);
+    return new Wallet(this.nameService, privateKey, this.blocks, this.remoteProcedureCall, this.ws);
   }
 
   /**

--- a/lib/services/hash/key-service.ts
+++ b/lib/services/hash/key-service.ts
@@ -1,4 +1,5 @@
 import { deriveAddress, derivePublicKey, deriveSecretKey, generateSeed } from 'nanocurrency';
+import { NanoAddress } from '../../shared/utils/address';
 
 export class KeyService {
   /**
@@ -37,9 +38,9 @@ export class KeyService {
    * @param publicKey - The public key to generate the address from, in hexadecimal format
    * @returns Address
    */
-  public static getAddress(publicKey: string): string {
+  public static getAddress(publicKey: string): NanoAddress {
     return deriveAddress(publicKey, {
       useNanoPrefix: true,
-    });
+    }) as NanoAddress;
   }
 }

--- a/lib/services/name/name-schemas.ts
+++ b/lib/services/name/name-schemas.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const NameInfo = z.object({
+  key: z.string(),
+});
+
+export type NameInfo = z.infer<typeof NameInfo>;

--- a/lib/services/name/name-service.ts
+++ b/lib/services/name/name-service.ts
@@ -1,0 +1,36 @@
+import { RpcConsummer } from '../../modules/rpc-consumer/rpc-consumer';
+import { NonaUserError } from '../../shared/errors/user-error';
+import {
+  NanoAddress,
+  NanoTarget,
+  NanoUsername,
+  isValidNanoAddress,
+  isValidNanoUsername,
+} from '../../shared/utils/address';
+import { KeyService } from '../hash/key-service';
+import { Rpc } from '../rpc/rpc';
+import { NameInfo } from './name-schemas';
+
+export class NameService extends RpcConsummer {
+  constructor() {
+    super(new Rpc({ url: 'http://rpc.nano.to' }));
+  }
+  public async resolveUsername(username: NanoUsername): Promise<NanoAddress> {
+    const res = await this.rpc.call('account_key', { account: username });
+    const { key } = this.parseHandler(res, NameInfo);
+    return KeyService.getAddress(key);
+  }
+
+  public async resolveTarget(target: NanoTarget): Promise<NanoAddress> {
+    if (isValidNanoUsername(target)) {
+      return this.resolveUsername(target);
+    }
+    if (isValidNanoAddress(target)) {
+      return target;
+    }
+
+    throw new NonaUserError(
+      `Invalid target ${target as string}. Should be either username (@*) or address (nano_*)`,
+    );
+  }
+}

--- a/lib/services/name/name-service.ts
+++ b/lib/services/name/name-service.ts
@@ -15,12 +15,25 @@ export class NameService extends RpcConsummer {
   constructor(rpc = new Rpc({ url: 'https://rpc.nano.to' })) {
     super(rpc);
   }
+
+  /**
+   * Resolves a username registered with the [Nano Name Service](http://nano.to) to a valid {@link NanoAddress}
+   *
+   * @param username - the {@link NanoUsername} to resolve
+   * @returns a promise of the resolve {@link NanoAddress}
+   */
   public async resolveUsername(username: NanoUsername): Promise<NanoAddress> {
     const res = await this.rpc.call('account_key', { account: username });
     const { key } = this.parseHandler(res, NameInfo);
     return KeyService.getAddress(key);
   }
 
+  /**
+   * Checks if the given target is a valid {@link NanoAddress} or a {@link NanoUsername}, which is resolved to a valid {@link NanoAddress}
+   *
+   * @param target - the {@link NanoTarget} to resolve
+   * @returns the resolve {@link NanoAddress}
+   */
   public async resolveTarget(target: NanoTarget): Promise<NanoAddress> {
     if (isValidNanoUsername(target)) {
       return this.resolveUsername(target);

--- a/lib/services/name/name-service.ts
+++ b/lib/services/name/name-service.ts
@@ -12,8 +12,8 @@ import { Rpc } from '../rpc/rpc';
 import { NameInfo } from './name-schemas';
 
 export class NameService extends RpcConsummer {
-  constructor() {
-    super(new Rpc({ url: 'http://rpc.nano.to' }));
+  constructor(rpc = new Rpc({ url: 'https://rpc.nano.to' })) {
+    super(rpc);
   }
   public async resolveUsername(username: NanoUsername): Promise<NanoAddress> {
     const res = await this.rpc.call('account_key', { account: username });

--- a/lib/services/rpc/rpc-interface.ts
+++ b/lib/services/rpc/rpc-interface.ts
@@ -1,3 +1,4 @@
 export interface RpcPostResponse {
-  error?: unknown;
+  error?: string | number;
+  message?: string;
 }

--- a/lib/services/rpc/rpc.ts
+++ b/lib/services/rpc/rpc.ts
@@ -26,8 +26,8 @@ export class Rpc {
         ...body,
       });
 
-      if (data.error) {
-        this.handleResponseDataError(data.error);
+      if (!!data.error) {
+        this.handleResponseDataError(data);
       }
 
       return data as unknown;
@@ -36,9 +36,15 @@ export class Rpc {
     }
   }
 
-  private handleResponseDataError(error: unknown): never {
-    if (typeof error === 'string') {
-      throw new NonaRpcError(error);
+  private handleResponseDataError(errorResponse: RpcPostResponse): never {
+    // normal RPC node error
+    if (typeof errorResponse.error === 'string') {
+      throw new NonaRpcError(errorResponse.error);
+    }
+
+    // RPC NameService error
+    if (typeof errorResponse.error === 'number' && typeof errorResponse.message === 'string') {
+      throw new NonaRpcError(errorResponse.message);
     }
 
     throw new NonaRpcError('Unknown error occurred from RPC call');

--- a/lib/services/rpc/rpc.ts
+++ b/lib/services/rpc/rpc.ts
@@ -26,7 +26,7 @@ export class Rpc {
         ...body,
       });
 
-      if (!!data.error) {
+      if (data.error) {
         this.handleResponseDataError(data);
       }
 

--- a/lib/shared/utils/address.ts
+++ b/lib/shared/utils/address.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 
 /**
+ * a username starting with '@' which will be checked with the {@link NanoNameService}
+ */
+export type NanoUsername = `@${string}`;
+
+export const isValidNanoUsername = (address: string): address is NanoUsername =>
+  address.startsWith('@');
+
+/**
  * a Nano address starting with 'nano_'
  */
 export type NanoAddress = `nano_${string}`;
@@ -10,3 +18,8 @@ export const isValidNanoAddress = (address: string): address is NanoAddress =>
 
 export const zNanoAddress = (): z.ZodEffects<z.ZodString, NanoAddress, string> =>
   z.string().refine(isValidNanoAddress, "Address has to start with 'nano_'");
+
+/**
+ * Either a {@link NanoAddress} or a {@link NanoUsername}
+ */
+export type NanoTarget = NanoAddress | NanoUsername;

--- a/lib/shared/utils/address.ts
+++ b/lib/shared/utils/address.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export type NanoAddress = `nano_${string}`;
+
+export const isValidNanoAddress = (address: string): address is NanoAddress =>
+  address.startsWith('nano_');
+
+export const zNanoAddress = () =>
+  z.string().refine(isValidNanoAddress, "Address has to start with 'nano_'");

--- a/lib/shared/utils/address.ts
+++ b/lib/shared/utils/address.ts
@@ -1,3 +1,4 @@
+import { checkAddress } from 'nanocurrency';
 import { z } from 'zod';
 
 /**
@@ -14,10 +15,10 @@ export const isValidNanoUsername = (address: string): address is NanoUsername =>
 export type NanoAddress = `nano_${string}`;
 
 export const isValidNanoAddress = (address: string): address is NanoAddress =>
-  address.startsWith('nano_');
+  checkAddress(address);
 
 export const zNanoAddress = (): z.ZodEffects<z.ZodString, NanoAddress, string> =>
-  z.string().refine(isValidNanoAddress, "Address has to start with 'nano_'");
+  z.string().refine(isValidNanoAddress, 'Invalid nano address');
 
 /**
  * Either a {@link NanoAddress} or a {@link NanoUsername}

--- a/lib/shared/utils/address.ts
+++ b/lib/shared/utils/address.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod';
 
+/**
+ * a Nano address starting with 'nano_'
+ */
 export type NanoAddress = `nano_${string}`;
 
 export const isValidNanoAddress = (address: string): address is NanoAddress =>
   address.startsWith('nano_');
 
-export const zNanoAddress = () =>
+export const zNanoAddress = (): z.ZodEffects<z.ZodString, NanoAddress, string> =>
   z.string().refine(isValidNanoAddress, "Address has to start with 'nano_'");

--- a/test/unit/modules/account.test.ts
+++ b/test/unit/modules/account.test.ts
@@ -4,6 +4,7 @@ import { Account } from '../../../lib/modules/account/account';
 import { ListenConfirmationParams } from '../../../lib/modules/account/account-interface';
 import { NonaWebSocket } from '../../../lib/modules/websocket/websocket';
 import { Rpc } from '../../../lib/services/rpc/rpc';
+import { randomNanoAddress, randomNanoAddresses } from '../../utils/utils';
 
 jest.mock('../../../lib/services/rpc/rpc');
 jest.mock('../../../lib/modules/websocket/websocket');
@@ -13,10 +14,12 @@ describe('Account', () => {
   let rpcMock: jest.Mocked<Rpc>;
   let websocketMock: jest.Mocked<NonaWebSocket>;
 
+  const accountAddressMock = randomNanoAddress();
+
   beforeEach(() => {
     rpcMock = new Rpc({ url: 'http://example.com' }) as jest.Mocked<Rpc>;
     websocketMock = new NonaWebSocket({ url: 'http://example.com' }) as jest.Mocked<NonaWebSocket>;
-    account = new Account('nano_test-address', websocketMock, rpcMock);
+    account = new Account(accountAddressMock, websocketMock, rpcMock);
   });
 
   describe('receivable', () => {
@@ -26,7 +29,7 @@ describe('Account', () => {
 
       const result = await account.receivable();
       expect(rpcMock.call).toHaveBeenCalledWith('receivable', {
-        account: 'nano_test-address',
+        account: accountAddressMock,
         count: 100,
         sorting: false,
       });
@@ -39,7 +42,7 @@ describe('Account', () => {
 
       const result = await account.receivable({ count: 2, sort: true });
       expect(rpcMock.call).toHaveBeenCalledWith('receivable', {
-        account: 'nano_test-address',
+        account: accountAddressMock,
         count: 2,
         sorting: true,
       });
@@ -81,7 +84,7 @@ describe('Account', () => {
       const result = await account.info();
       expect(rpcMock.call).toHaveBeenCalledWith('account_info', {
         representative: false,
-        account: 'nano_test-address',
+        account: accountAddressMock,
       });
       expect(result).toEqual({
         ...rpcResponse,
@@ -121,7 +124,7 @@ describe('Account', () => {
 
       const result = await account.balance();
       expect(rpcMock.call).toHaveBeenCalledWith('account_balance', {
-        account: 'nano_test-address',
+        account: accountAddressMock,
       });
       expect(result).toEqual({
         balance: '0.001',
@@ -158,7 +161,7 @@ describe('Account', () => {
 
       expect(websocketMock.confirmation).toHaveBeenCalledWith({
         ...params,
-        filter: { ...params.filter, accounts: ['nano_test-address'] },
+        filter: { ...params.filter, accounts: [accountAddressMock] },
       });
       expect(result).toBe(subscriptionMock);
     });
@@ -166,12 +169,14 @@ describe('Account', () => {
 
   describe('history', () => {
     it('should fetch and return account history', async () => {
+      const [fromAccount] = randomNanoAddresses(1);
+
       const rpcResponse = {
-        account: 'nano_test-address',
+        account: accountAddressMock,
         history: [
           {
             type: 'send',
-            account: 'nano_test-address',
+            account: fromAccount,
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -179,7 +184,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'nano_test-address',
+            account: fromAccount,
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -193,7 +198,7 @@ describe('Account', () => {
       const result = await account.history();
 
       expect(rpcMock.call).toHaveBeenCalledWith('account_history', {
-        account: 'nano_test-address',
+        account: accountAddressMock,
         count: 100,
         raw: false,
       });
@@ -202,7 +207,7 @@ describe('Account', () => {
         history: [
           {
             type: 'send',
-            account: 'nano_test-address',
+            account: fromAccount,
             amount: '0.001',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -210,7 +215,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'nano_test-address',
+            account: fromAccount,
             amount: '0.001',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -224,11 +229,11 @@ describe('Account', () => {
 
     it('should fetch and return raw account history', async () => {
       const rpcResponse = {
-        account: 'nano_test-address',
+        account: accountAddressMock,
         history: [
           {
             type: 'send',
-            account: 'nano_test-address',
+            account: accountAddressMock,
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -244,7 +249,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'nano_test-address',
+            account: accountAddressMock,
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -266,7 +271,7 @@ describe('Account', () => {
       const result = await account.history({ count: 2, raw: true });
 
       expect(rpcMock.call).toHaveBeenCalledWith('account_history', {
-        account: 'nano_test-address',
+        account: accountAddressMock,
         count: 2,
         raw: true,
       });
@@ -275,7 +280,7 @@ describe('Account', () => {
         history: [
           {
             type: 'send',
-            account: 'nano_test-address',
+            account: accountAddressMock,
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -291,7 +296,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'nano_test-address',
+            account: accountAddressMock,
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -319,7 +324,7 @@ describe('Account', () => {
 
       const result = await account.blockCount();
       expect(rpcMock.call).toHaveBeenCalledWith('account_block_count', {
-        account: 'nano_test-address',
+        account: accountAddressMock,
       });
       expect(result).toBe(10);
     });

--- a/test/unit/modules/account.test.ts
+++ b/test/unit/modules/account.test.ts
@@ -16,7 +16,7 @@ describe('Account', () => {
   beforeEach(() => {
     rpcMock = new Rpc({ url: 'http://example.com' }) as jest.Mocked<Rpc>;
     websocketMock = new NonaWebSocket({ url: 'http://example.com' }) as jest.Mocked<NonaWebSocket>;
-    account = new Account('test-address', websocketMock, rpcMock);
+    account = new Account('nano_test-address', websocketMock, rpcMock);
   });
 
   describe('receivable', () => {
@@ -26,7 +26,7 @@ describe('Account', () => {
 
       const result = await account.receivable();
       expect(rpcMock.call).toHaveBeenCalledWith('receivable', {
-        account: 'test-address',
+        account: 'nano_test-address',
         count: 100,
         sorting: false,
       });
@@ -39,7 +39,7 @@ describe('Account', () => {
 
       const result = await account.receivable({ count: 2, sort: true });
       expect(rpcMock.call).toHaveBeenCalledWith('receivable', {
-        account: 'test-address',
+        account: 'nano_test-address',
         count: 2,
         sorting: true,
       });
@@ -81,7 +81,7 @@ describe('Account', () => {
       const result = await account.info();
       expect(rpcMock.call).toHaveBeenCalledWith('account_info', {
         representative: false,
-        account: 'test-address',
+        account: 'nano_test-address',
       });
       expect(result).toEqual({
         ...rpcResponse,
@@ -101,7 +101,7 @@ describe('Account', () => {
         account_version: '1',
         confirmation_height: '5',
         confirmation_height_frontier: 'block-confirmation',
-        representative: 'test-rep',
+        representative: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
       };
       rpcMock.call.mockResolvedValue(rpcResponse);
 
@@ -121,7 +121,7 @@ describe('Account', () => {
 
       const result = await account.balance();
       expect(rpcMock.call).toHaveBeenCalledWith('account_balance', {
-        account: 'test-address',
+        account: 'nano_test-address',
       });
       expect(result).toEqual({
         balance: '0.001',
@@ -152,13 +152,13 @@ describe('Account', () => {
         next: jest.fn() as unknown as () => void,
         error: jest.fn() as unknown as () => void,
         complete: jest.fn() as unknown as () => void,
-        filter: { subtype: ['send'], from: ['test-from'], to: ['test-to'] },
+        filter: { subtype: ['send'], to: ['nano_test-to'] },
       };
       const result = account.listenConfirmation(params);
 
       expect(websocketMock.confirmation).toHaveBeenCalledWith({
         ...params,
-        filter: { ...params.filter, accounts: ['test-address'] },
+        filter: { ...params.filter, accounts: ['nano_test-address'] },
       });
       expect(result).toBe(subscriptionMock);
     });
@@ -167,11 +167,11 @@ describe('Account', () => {
   describe('history', () => {
     it('should fetch and return account history', async () => {
       const rpcResponse = {
-        account: 'test-address',
+        account: 'nano_test-address',
         history: [
           {
             type: 'send',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -179,7 +179,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -193,7 +193,7 @@ describe('Account', () => {
       const result = await account.history();
 
       expect(rpcMock.call).toHaveBeenCalledWith('account_history', {
-        account: 'test-address',
+        account: 'nano_test-address',
         count: 100,
         raw: false,
       });
@@ -202,7 +202,7 @@ describe('Account', () => {
         history: [
           {
             type: 'send',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '0.001',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -210,7 +210,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '0.001',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -224,11 +224,11 @@ describe('Account', () => {
 
     it('should fetch and return raw account history', async () => {
       const rpcResponse = {
-        account: 'test-address',
+        account: 'nano_test-address',
         history: [
           {
             type: 'send',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -244,7 +244,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: '123456789',
@@ -266,7 +266,7 @@ describe('Account', () => {
       const result = await account.history({ count: 2, raw: true });
 
       expect(rpcMock.call).toHaveBeenCalledWith('account_history', {
-        account: 'test-address',
+        account: 'nano_test-address',
         count: 2,
         raw: true,
       });
@@ -275,7 +275,7 @@ describe('Account', () => {
         history: [
           {
             type: 'send',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -291,7 +291,7 @@ describe('Account', () => {
           },
           {
             type: 'receive',
-            account: 'test-address',
+            account: 'nano_test-address',
             amount: '1000000000000000000000000000',
             hash: 'block-hash',
             local_timestamp: 123456789,
@@ -319,7 +319,7 @@ describe('Account', () => {
 
       const result = await account.blockCount();
       expect(rpcMock.call).toHaveBeenCalledWith('account_block_count', {
-        account: 'test-address',
+        account: 'nano_test-address',
       });
       expect(result).toBe(10);
     });
@@ -337,12 +337,12 @@ describe('Account', () => {
         account_version: '1',
         confirmation_height: '5',
         confirmation_height_frontier: 'block-confirmation',
-        representative: 'test-rep',
+        representative: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
       };
       rpcMock.call.mockResolvedValue(rpcResponse);
 
       const result = await account.representative();
-      expect(result).toBe('test-rep');
+      expect(result).toBe(rpcResponse.representative);
     });
   });
 

--- a/test/unit/modules/blocks.test.ts
+++ b/test/unit/modules/blocks.test.ts
@@ -2,6 +2,7 @@ import { Blocks } from '../../../lib/modules/blocks/blocks';
 import { CreateBlockParams } from '../../../lib/modules/blocks/blocks-interface';
 import { Block, BlockInfo } from '../../../lib/modules/blocks/blocks-schema';
 import { Rpc } from '../../../lib/services/rpc/rpc';
+import { randomNanoAddresses } from '../../utils/utils';
 
 // TODO: separate all mthods tests in describe blocks
 describe('Blocks', () => {
@@ -29,10 +30,12 @@ describe('Blocks', () => {
   });
 
   it('should call block_create RPC method with the provided params and parse the result', async () => {
+    const [fromAccount, representative, linkAsAccount] = randomNanoAddresses(3);
+
     const createParams: CreateBlockParams = {
-      account: 'nano_account',
+      account: fromAccount,
       previous: 'previousHash',
-      representative: 'nano_representative',
+      representative: representative,
       balance: '1000',
       key: 'privateKey',
       link: 'link',
@@ -42,7 +45,7 @@ describe('Blocks', () => {
     const block: Block['block'] = {
       ...createParamsWithoutKey,
       type: 'state',
-      link_as_account: 'nano_linkAsAccount',
+      link_as_account: linkAsAccount,
       signature: 'signature',
       work: 'work',
     };
@@ -86,9 +89,11 @@ describe('Blocks', () => {
   });
 
   it('should call block_info RPC method with the provided hash and parse the result', async () => {
+    const [blockAccount, contentsAccount, contentsLinkAsAccount] = randomNanoAddresses(3);
+
     const hash = 'blockHash';
     const infoResponse = {
-      block_account: 'nano_block_account',
+      block_account: blockAccount,
       amount: 'amount',
       balance: 'balance',
       height: 'height',
@@ -97,12 +102,12 @@ describe('Blocks', () => {
       confirmed: 'confirmed',
       contents: {
         type: 'type',
-        account: 'nano_account',
+        account: contentsAccount,
         previous: 'previous',
         representative: 'representative',
         balance: 'balance',
         link: 'link',
-        link_as_account: 'nano_link_as_account',
+        link_as_account: contentsLinkAsAccount,
         signature: 'signature',
         work: 'work',
       },

--- a/test/unit/modules/blocks.test.ts
+++ b/test/unit/modules/blocks.test.ts
@@ -30,9 +30,9 @@ describe('Blocks', () => {
 
   it('should call block_create RPC method with the provided params and parse the result', async () => {
     const createParams: CreateBlockParams = {
-      account: 'account',
+      account: 'nano_account',
       previous: 'previousHash',
-      representative: 'representative',
+      representative: 'nano_representative',
       balance: '1000',
       key: 'privateKey',
       link: 'link',
@@ -42,7 +42,7 @@ describe('Blocks', () => {
     const block: Block['block'] = {
       ...createParamsWithoutKey,
       type: 'state',
-      link_as_account: 'linkAsAccount',
+      link_as_account: 'nano_linkAsAccount',
       signature: 'signature',
       work: 'work',
     };
@@ -62,12 +62,12 @@ describe('Blocks', () => {
   it('should call process RPC method with the provided block and subtype, and parse the result', async () => {
     const block: Block['block'] = {
       type: 'state',
-      account: 'account',
+      account: 'nano_account',
       previous: 'previousHash',
-      representative: 'representative',
+      representative: 'nano_representative',
       balance: '1000',
       link: 'link',
-      link_as_account: 'linkAsAccount',
+      link_as_account: 'nano_linkAsAccount',
       signature: 'signature',
       work: 'work',
     };
@@ -88,7 +88,7 @@ describe('Blocks', () => {
   it('should call block_info RPC method with the provided hash and parse the result', async () => {
     const hash = 'blockHash';
     const infoResponse = {
-      block_account: 'block_account',
+      block_account: 'nano_block_account',
       amount: 'amount',
       balance: 'balance',
       height: 'height',
@@ -97,12 +97,12 @@ describe('Blocks', () => {
       confirmed: 'confirmed',
       contents: {
         type: 'type',
-        account: 'account',
+        account: 'nano_account',
         previous: 'previous',
         representative: 'representative',
         balance: 'balance',
         link: 'link',
-        link_as_account: 'link_as_account',
+        link_as_account: 'nano_link_as_account',
         signature: 'signature',
         work: 'work',
       },

--- a/test/unit/modules/key.test.ts
+++ b/test/unit/modules/key.test.ts
@@ -16,7 +16,7 @@ describe('Key', () => {
       const seed = 'test-seed';
       const privateKey = 'privateKey';
       const publicKey = 'publicKey';
-      const address = 'address';
+      const address = 'nano_address';
 
       keyServiceMock.getPrivateKey.mockReturnValue(privateKey);
       keyServiceMock.getPublicKey.mockReturnValue(publicKey);
@@ -33,7 +33,7 @@ describe('Key', () => {
       const generatedSeed = 'generated-seed';
       const privateKey = 'privateKey';
       const publicKey = 'publicKey';
-      const address = 'address';
+      const address = 'nano_address';
 
       keyServiceMock.generateSeed.mockResolvedValue(generatedSeed);
       keyServiceMock.getPrivateKey.mockReturnValue(privateKey);
@@ -53,7 +53,7 @@ describe('Key', () => {
     it('should expand private key to public key and address', () => {
       const privateKey = 'privateKey';
       const publicKey = 'publicKey';
-      const address = 'address';
+      const address = 'nano_address';
 
       keyServiceMock.getPublicKey.mockReturnValue(publicKey);
       keyServiceMock.getAddress.mockReturnValue(address);

--- a/test/unit/modules/node.test.ts
+++ b/test/unit/modules/node.test.ts
@@ -1,5 +1,3 @@
-import { jest } from '@jest/globals';
-
 import { Node } from '../../../lib/modules/node/node';
 import { Rpc } from '../../../lib/services/rpc/rpc';
 

--- a/test/unit/modules/wallet.test.ts
+++ b/test/unit/modules/wallet.test.ts
@@ -8,6 +8,7 @@ import { KeyService } from '../../../lib/services/hash/key-service';
 import { NameService } from '../../../lib/services/name/name-service';
 import { Rpc } from '../../../lib/services/rpc/rpc';
 import { NonaUserError } from '../../../lib/shared/errors/user-error';
+import { randomNanoAddress, randomNanoAddresses, randomPublicKey } from '../../utils/utils';
 
 jest.mock('../../../lib/services/rpc/rpc');
 jest.mock('../../../lib/modules/blocks/blocks');
@@ -23,9 +24,12 @@ describe('Wallet class', () => {
   let websocketMock: jest.Mocked<NonaWebSocket>;
   const privateKey = 'privateKey';
 
+  const walletAddressMock = randomNanoAddress();
+  const publicKeyMock = randomPublicKey();
+
   beforeEach(() => {
-    keyServiceMock.getPublicKey.mockReturnValue('publicKey');
-    keyServiceMock.getAddress.mockReturnValue('nano_address');
+    keyServiceMock.getPublicKey.mockReturnValue(publicKeyMock);
+    keyServiceMock.getAddress.mockReturnValue(walletAddressMock);
 
     nameServiceMock = new NameService();
     jest.spyOn(nameServiceMock, 'resolveUsername').mockResolvedValue('nano_resolved_address');
@@ -37,23 +41,24 @@ describe('Wallet class', () => {
   });
 
   it('should initialize properties correctly', () => {
-    expect(wallet.publicKey).toEqual('publicKey');
-    expect(wallet.address).toEqual('nano_address');
+    expect(wallet.publicKey).toEqual(publicKeyMock);
+    expect(wallet.address).toEqual(walletAddressMock);
   });
 
   describe('open', () => {
     it('should open an account and return the hash of the opened block', async () => {
+      const representative = randomNanoAddress();
       const lastHashes = { blockHash: '100' };
       wallet.receivable = jest.fn().mockResolvedValue(lastHashes);
       blocksMock.create.mockResolvedValue({ hash: 'createdHash' } as any);
       blocksMock.process.mockResolvedValue('processedHash');
 
-      const result = await wallet.open('nano_representative');
+      const result = await wallet.open(representative);
       expect(wallet.receivable).toHaveBeenCalledWith({ count: 1, sort: true });
       expect(blocksMock.create).toHaveBeenCalledWith({
         previous: '0',
-        representative: 'nano_representative',
-        account: 'nano_address',
+        representative: representative,
+        account: walletAddressMock,
         link: 'blockHash',
         balance: '100',
         key: privateKey,
@@ -64,8 +69,9 @@ describe('Wallet class', () => {
 
     it('should throw an error if no receivable blocks are available', async () => {
       wallet.receivable = jest.fn().mockResolvedValue({});
-      await expect(wallet.open('nano_representative')).rejects.toThrow(NonaUserError);
-      await expect(wallet.open('nano_representative')).rejects.toThrow('No receivable blocks');
+      const representative = randomNanoAddress();
+      await expect(wallet.open(representative)).rejects.toThrow(NonaUserError);
+      await expect(wallet.open(representative)).rejects.toThrow('No receivable blocks');
     });
   });
 
@@ -120,7 +126,7 @@ describe('Wallet class', () => {
         raw: true,
       });
       expect(blocksMock.receiveBlock).toHaveBeenCalledWith({
-        account: 'nano_address',
+        account: walletAddressMock,
         previous: 'frontierHash',
         representative: 'nano_representative',
         balance: '6000000000000000000000000000000',
@@ -198,10 +204,11 @@ describe('Wallet class', () => {
     });
 
     it('should receive multiple transactions and return hashes of the received blocks', async () => {
+      const representative = randomNanoAddress();
       const info = {
         balance: '1000000000000000000000000000000',
         frontier: 'frontierHash',
-        representative: 'nano_representative',
+        representative: representative,
       };
       const hashInfo = { amount: '2000000000000000000000000000000' };
       wallet.info = jest.fn().mockResolvedValue(info);
@@ -215,17 +222,17 @@ describe('Wallet class', () => {
       expect(blocksMock.info).toHaveBeenCalledTimes(hashes.length);
       expect(blocksMock.receiveBlock).toHaveBeenCalledTimes(hashes.length);
       expect(blocksMock.receiveBlock).toHaveBeenNthCalledWith(1, {
-        account: 'nano_address',
+        account: walletAddressMock,
         previous: 'frontierHash',
-        representative: 'nano_representative',
+        representative: representative,
         balance: '3000000000000000000000000000000',
         link: 'hash1',
         key: privateKey,
       });
       expect(blocksMock.receiveBlock).toHaveBeenNthCalledWith(2, {
-        account: 'nano_address',
+        account: walletAddressMock,
         previous: 'processedHash',
-        representative: 'nano_representative',
+        representative: representative,
         balance: '5000000000000000000000000000000',
         link: 'hash2',
         key: privateKey,
@@ -236,55 +243,58 @@ describe('Wallet class', () => {
 
   describe('send', () => {
     it('should send a transaction to the specified address and return the hash of the sent block', async () => {
+      const [representative, toAccount] = randomNanoAddresses(2);
       const info = {
         balance: '5000000000000000000000000000000',
         frontier: 'frontierHash',
-        representative: 'nano_representative',
+        representative: representative,
       };
       wallet.info = jest.fn().mockResolvedValue(info);
       blocksMock.create.mockResolvedValue({ hash: 'createdSendHash' } as any);
       blocksMock.process.mockResolvedValue('processedSendHash');
       KeyService.getPublicKey = jest.fn().mockReturnValue('publicKey');
 
-      const result = await wallet.send('nano_destinationAddress', '1');
+      const result = await wallet.send(toAccount, '1');
       expect(wallet.info).toHaveBeenCalledWith({
         representative: true,
         raw: true,
       });
       expect(blocksMock.create).toHaveBeenCalledWith({
-        account: 'nano_address',
+        account: walletAddressMock,
         previous: 'frontierHash',
-        representative: 'nano_representative',
+        representative: representative,
         balance: '4000000000000000000000000000000', // Adjusted for unit conversion in test setup
         link: 'publicKey',
         key: privateKey,
       });
-      expect(KeyService.getPublicKey).toHaveBeenCalledWith('destinationAddress');
+      expect(KeyService.getPublicKey).toHaveBeenCalledWith(toAccount);
       expect(blocksMock.process).toHaveBeenCalledWith({ hash: 'createdSendHash' }, 'send');
       expect(result).toBe('processedSendHash');
     });
 
     it('should throw a NonaUserError if the amount is not a valid number', async () => {
-      await expect(wallet.send('nano_destinationAddress', '')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('nano_destinationAddress', '')).rejects.toThrow('Invalid amount');
-      await expect(wallet.send('nano_destinationAddress', '-12')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('nano_destinationAddress', '-12')).rejects.toThrow('Invalid amount');
-      await expect(wallet.send('nano_destinationAddress', '0')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('nano_destinationAddress', '0')).rejects.toThrow('Invalid amount');
+      const destinationAddress = randomNanoAddress();
+
+      await expect(wallet.send(destinationAddress, '')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send(destinationAddress, '')).rejects.toThrow('Invalid amount');
+      await expect(wallet.send(destinationAddress, '-12')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send(destinationAddress, '-12')).rejects.toThrow('Invalid amount');
+      await expect(wallet.send(destinationAddress, '0')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send(destinationAddress, '0')).rejects.toThrow('Invalid amount');
     });
 
     it('sould throw a NonaUserError if the balance of the acount is insufficient', async () => {
+      const [destinationAddress, representative] = randomNanoAddresses(2);
+
       const info = {
         balance: '0',
         frontier: 'frontierHash',
-        representative: 'nano_representative',
+        representative: representative,
       };
       wallet.info = jest.fn().mockResolvedValue(info);
 
-      await expect(wallet.send('nano_destinationAddress', '1')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('nano_destinationAddress', '1')).rejects.toThrow(
-        'Insufficient balance',
-      );
+      await expect(wallet.send(destinationAddress, '1')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send(destinationAddress, '1')).rejects.toThrow('Insufficient balance');
     });
   });
 
@@ -369,19 +379,20 @@ describe('Wallet class', () => {
 
   describe('change', () => {
     it('should change the representative of the account and return the hash of the changed block', async () => {
+      const newRepresentative = randomNanoAddress();
       const info = { balance: '1000', frontier: 'frontierHash' };
       wallet.info = jest.fn().mockResolvedValue(info);
       blocksMock.create.mockResolvedValue({ hash: 'createdChangeHash' } as any);
       blocksMock.process.mockResolvedValue('processedChangeHash');
 
-      const result = await wallet.change('nano_newRepresentative');
+      const result = await wallet.change(newRepresentative);
       expect(wallet.info).toHaveBeenCalledWith({
         raw: true,
       });
       expect(blocksMock.create).toHaveBeenCalledWith({
-        account: 'nano_address',
+        account: walletAddressMock,
         previous: 'frontierHash',
-        representative: 'nano_newRepresentative',
+        representative: newRepresentative,
         balance: '1000',
         link: '0',
         key: privateKey,

--- a/test/unit/modules/wallet.test.ts
+++ b/test/unit/modules/wallet.test.ts
@@ -5,6 +5,7 @@ import { Blocks } from '../../../lib/modules/blocks/blocks';
 import { Wallet } from '../../../lib/modules/wallet/wallet';
 import { NonaWebSocket } from '../../../lib/modules/websocket/websocket';
 import { KeyService } from '../../../lib/services/hash/key-service';
+import { NameService } from '../../../lib/services/name/name-service';
 import { Rpc } from '../../../lib/services/rpc/rpc';
 import { NonaUserError } from '../../../lib/shared/errors/user-error';
 
@@ -15,6 +16,7 @@ jest.mock('../../../lib/services/hash/key-service');
 
 describe('Wallet class', () => {
   const keyServiceMock = KeyService as jest.Mocked<typeof KeyService>;
+  let nameServiceMock: NameService;
   let wallet: Wallet;
   let rpcMock: jest.Mocked<Rpc>;
   let blocksMock: jest.Mocked<Blocks>;
@@ -24,10 +26,14 @@ describe('Wallet class', () => {
   beforeEach(() => {
     keyServiceMock.getPublicKey.mockReturnValue('publicKey');
     keyServiceMock.getAddress.mockReturnValue('nano_address');
+
+    nameServiceMock = new NameService();
+    jest.spyOn(nameServiceMock, 'resolveUsername').mockResolvedValue('nano_resolved_address');
+
     rpcMock = new Rpc({ url: 'http://example.com' }) as jest.Mocked<Rpc>;
     blocksMock = new Blocks(rpcMock) as jest.Mocked<Blocks>;
     websocketMock = new NonaWebSocket({ url: 'http://example.com' }) as jest.Mocked<NonaWebSocket>;
-    wallet = new Wallet(privateKey, blocksMock, rpcMock, websocketMock);
+    wallet = new Wallet(nameServiceMock, privateKey, blocksMock, rpcMock, websocketMock);
   });
 
   it('should initialize properties correctly', () => {

--- a/test/unit/modules/wallet.test.ts
+++ b/test/unit/modules/wallet.test.ts
@@ -23,7 +23,7 @@ describe('Wallet class', () => {
 
   beforeEach(() => {
     keyServiceMock.getPublicKey.mockReturnValue('publicKey');
-    keyServiceMock.getAddress.mockReturnValue('address');
+    keyServiceMock.getAddress.mockReturnValue('nano_address');
     rpcMock = new Rpc({ url: 'http://example.com' }) as jest.Mocked<Rpc>;
     blocksMock = new Blocks(rpcMock) as jest.Mocked<Blocks>;
     websocketMock = new NonaWebSocket({ url: 'http://example.com' }) as jest.Mocked<NonaWebSocket>;
@@ -32,7 +32,7 @@ describe('Wallet class', () => {
 
   it('should initialize properties correctly', () => {
     expect(wallet.publicKey).toEqual('publicKey');
-    expect(wallet.address).toEqual('address');
+    expect(wallet.address).toEqual('nano_address');
   });
 
   describe('open', () => {
@@ -42,12 +42,12 @@ describe('Wallet class', () => {
       blocksMock.create.mockResolvedValue({ hash: 'createdHash' } as any);
       blocksMock.process.mockResolvedValue('processedHash');
 
-      const result = await wallet.open('representative');
+      const result = await wallet.open('nano_representative');
       expect(wallet.receivable).toHaveBeenCalledWith({ count: 1, sort: true });
       expect(blocksMock.create).toHaveBeenCalledWith({
         previous: '0',
-        representative: 'representative',
-        account: 'address',
+        representative: 'nano_representative',
+        account: 'nano_address',
         link: 'blockHash',
         balance: '100',
         key: privateKey,
@@ -58,8 +58,8 @@ describe('Wallet class', () => {
 
     it('should throw an error if no receivable blocks are available', async () => {
       wallet.receivable = jest.fn().mockResolvedValue({});
-      await expect(wallet.open('representative')).rejects.toThrow(NonaUserError);
-      await expect(wallet.open('representative')).rejects.toThrow('No receivable blocks');
+      await expect(wallet.open('nano_representative')).rejects.toThrow(NonaUserError);
+      await expect(wallet.open('nano_representative')).rejects.toThrow('No receivable blocks');
     });
   });
 
@@ -101,7 +101,7 @@ describe('Wallet class', () => {
       const info = {
         balance: '1000000000000000000000000000000',
         frontier: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
       };
       const hashInfo = { amount: '5000000000000000000000000000000' };
       wallet.info = jest.fn().mockResolvedValue(info);
@@ -114,9 +114,9 @@ describe('Wallet class', () => {
         raw: true,
       });
       expect(blocksMock.receiveBlock).toHaveBeenCalledWith({
-        account: 'address',
+        account: 'nano_address',
         previous: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
         balance: '6000000000000000000000000000000',
         link: 'transactionHash',
         key: 'privateKey',
@@ -195,7 +195,7 @@ describe('Wallet class', () => {
       const info = {
         balance: '1000000000000000000000000000000',
         frontier: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
       };
       const hashInfo = { amount: '2000000000000000000000000000000' };
       wallet.info = jest.fn().mockResolvedValue(info);
@@ -209,17 +209,17 @@ describe('Wallet class', () => {
       expect(blocksMock.info).toHaveBeenCalledTimes(hashes.length);
       expect(blocksMock.receiveBlock).toHaveBeenCalledTimes(hashes.length);
       expect(blocksMock.receiveBlock).toHaveBeenNthCalledWith(1, {
-        account: 'address',
+        account: 'nano_address',
         previous: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
         balance: '3000000000000000000000000000000',
         link: 'hash1',
         key: privateKey,
       });
       expect(blocksMock.receiveBlock).toHaveBeenNthCalledWith(2, {
-        account: 'address',
+        account: 'nano_address',
         previous: 'processedHash',
-        representative: 'representative',
+        representative: 'nano_representative',
         balance: '5000000000000000000000000000000',
         link: 'hash2',
         key: privateKey,
@@ -233,22 +233,22 @@ describe('Wallet class', () => {
       const info = {
         balance: '5000000000000000000000000000000',
         frontier: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
       };
       wallet.info = jest.fn().mockResolvedValue(info);
       blocksMock.create.mockResolvedValue({ hash: 'createdSendHash' } as any);
       blocksMock.process.mockResolvedValue('processedSendHash');
       KeyService.getPublicKey = jest.fn().mockReturnValue('publicKey');
 
-      const result = await wallet.send('destinationAddress', '1');
+      const result = await wallet.send('nano_destinationAddress', '1');
       expect(wallet.info).toHaveBeenCalledWith({
         representative: true,
         raw: true,
       });
       expect(blocksMock.create).toHaveBeenCalledWith({
-        account: 'address',
+        account: 'nano_address',
         previous: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
         balance: '4000000000000000000000000000000', // Adjusted for unit conversion in test setup
         link: 'publicKey',
         key: privateKey,
@@ -259,24 +259,26 @@ describe('Wallet class', () => {
     });
 
     it('should throw a NonaUserError if the amount is not a valid number', async () => {
-      await expect(wallet.send('destinationAddress', '')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('destinationAddress', '')).rejects.toThrow('Invalid amount');
-      await expect(wallet.send('destinationAddress', '-12')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('destinationAddress', '-12')).rejects.toThrow('Invalid amount');
-      await expect(wallet.send('destinationAddress', '0')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('destinationAddress', '0')).rejects.toThrow('Invalid amount');
+      await expect(wallet.send('nano_destinationAddress', '')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send('nano_destinationAddress', '')).rejects.toThrow('Invalid amount');
+      await expect(wallet.send('nano_destinationAddress', '-12')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send('nano_destinationAddress', '-12')).rejects.toThrow('Invalid amount');
+      await expect(wallet.send('nano_destinationAddress', '0')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send('nano_destinationAddress', '0')).rejects.toThrow('Invalid amount');
     });
 
     it('sould throw a NonaUserError if the balance of the acount is insufficient', async () => {
       const info = {
         balance: '0',
         frontier: 'frontierHash',
-        representative: 'representative',
+        representative: 'nano_representative',
       };
       wallet.info = jest.fn().mockResolvedValue(info);
 
-      await expect(wallet.send('destinationAddress', '1')).rejects.toThrow(NonaUserError);
-      await expect(wallet.send('destinationAddress', '1')).rejects.toThrow('Insufficient balance');
+      await expect(wallet.send('nano_destinationAddress', '1')).rejects.toThrow(NonaUserError);
+      await expect(wallet.send('nano_destinationAddress', '1')).rejects.toThrow(
+        'Insufficient balance',
+      );
     });
   });
 
@@ -366,14 +368,14 @@ describe('Wallet class', () => {
       blocksMock.create.mockResolvedValue({ hash: 'createdChangeHash' } as any);
       blocksMock.process.mockResolvedValue('processedChangeHash');
 
-      const result = await wallet.change('newRepresentative');
+      const result = await wallet.change('nano_newRepresentative');
       expect(wallet.info).toHaveBeenCalledWith({
         raw: true,
       });
       expect(blocksMock.create).toHaveBeenCalledWith({
-        account: 'address',
+        account: 'nano_address',
         previous: 'frontierHash',
-        representative: 'newRepresentative',
+        representative: 'nano_newRepresentative',
         balance: '1000',
         link: '0',
         key: privateKey,

--- a/test/unit/modules/websocket/confirmation/websocket-confirmation-helper.test.ts
+++ b/test/unit/modules/websocket/confirmation/websocket-confirmation-helper.test.ts
@@ -11,18 +11,18 @@ describe('WebSocket Confirmation Functions', () => {
   describe('messageMapper', () => {
     it('should map a confirmation message to a ConfirmationBlock', () => {
       const mockMessage = {
-        account: 'rootAccount',
+        account: 'nano_rootAccount',
         amount: '1000000000000000000000000000000', // 1 nano in raw unit
         hash: 'hashValue',
         confirmation_type: 'confirmation_type',
         block: {
           type: 'typeValue',
-          account: 'blockAccount',
+          account: 'nano_blockAccount',
           previous: 'previousHash',
-          representative: 'representativeValue',
+          representative: 'nano_representativeValue',
           balance: '2000000000000000000000000000000',
           link: 'linkValue',
-          link_as_account: 'toAccount',
+          link_as_account: 'nano_toAccount',
           signature: 'signatureValue',
           work: 'workValue',
           subtype: 'send',
@@ -32,17 +32,17 @@ describe('WebSocket Confirmation Functions', () => {
       const result = websocketConfirmationHelper.messageMapper(mockMessage);
 
       expect(result).toEqual({
-        account: 'rootAccount',
+        account: 'nano_rootAccount',
         amount: '1',
         hash: 'hashValue',
         confirmationType: 'confirmation_type',
         block: {
-          account: 'blockAccount',
+          account: 'nano_blockAccount',
           previous: 'previousHash',
-          representative: 'representativeValue',
+          representative: 'nano_representativeValue',
           balance: '2',
           link: 'linkValue',
-          linkAsAccount: 'toAccount',
+          linkAsAccount: 'nano_toAccount',
           signature: 'signatureValue',
           work: 'workValue',
           subtype: 'send',

--- a/test/unit/modules/websocket/confirmation/websocket-confirmation-helper.test.ts
+++ b/test/unit/modules/websocket/confirmation/websocket-confirmation-helper.test.ts
@@ -1,5 +1,6 @@
 import { WebSocketConfirmationHelper } from '../../../../../lib/modules/websocket/confirmation/websocket-confirmation-helper';
 import { NonaParseError } from '../../../../../lib/shared/errors/parse-error';
+import { randomNanoAddresses } from '../../../../utils/utils';
 
 describe('WebSocket Confirmation Functions', () => {
   let websocketConfirmationHelper: WebSocketConfirmationHelper;
@@ -9,20 +10,22 @@ describe('WebSocket Confirmation Functions', () => {
   });
 
   describe('messageMapper', () => {
+    const [rootAccount, blockAccount, representative, toAccount] = randomNanoAddresses(4);
+
     it('should map a confirmation message to a ConfirmationBlock', () => {
       const mockMessage = {
-        account: 'nano_rootAccount',
+        account: rootAccount,
         amount: '1000000000000000000000000000000', // 1 nano in raw unit
         hash: 'hashValue',
         confirmation_type: 'confirmation_type',
         block: {
           type: 'typeValue',
-          account: 'nano_blockAccount',
+          account: blockAccount,
           previous: 'previousHash',
-          representative: 'nano_representativeValue',
+          representative: representative,
           balance: '2000000000000000000000000000000',
           link: 'linkValue',
-          link_as_account: 'nano_toAccount',
+          link_as_account: toAccount,
           signature: 'signatureValue',
           work: 'workValue',
           subtype: 'send',
@@ -32,17 +35,17 @@ describe('WebSocket Confirmation Functions', () => {
       const result = websocketConfirmationHelper.messageMapper(mockMessage);
 
       expect(result).toEqual({
-        account: 'nano_rootAccount',
+        account: rootAccount,
         amount: '1',
         hash: 'hashValue',
         confirmationType: 'confirmation_type',
         block: {
-          account: 'nano_blockAccount',
+          account: blockAccount,
           previous: 'previousHash',
-          representative: 'nano_representativeValue',
+          representative: representative,
           balance: '2',
           link: 'linkValue',
-          linkAsAccount: 'nano_toAccount',
+          linkAsAccount: toAccount,
           signature: 'signatureValue',
           work: 'workValue',
           subtype: 'send',

--- a/test/unit/nona.test.ts
+++ b/test/unit/nona.test.ts
@@ -2,6 +2,7 @@ import { deriveAddress, derivePublicKey, deriveSecretKey } from 'nanocurrency';
 
 import { Nona } from '../../lib/nona';
 import { Rpc } from '../../lib/services/rpc/rpc';
+import { NanoAddress } from '../../lib/shared/utils/address';
 
 describe('Nona', () => {
   let nona: Nona;
@@ -10,7 +11,7 @@ describe('Nona', () => {
   const seed = 'cca6fda2102c958239b2e0f02e688414c23939271b7bcfe0d5014ab246071c12';
   const privateKey = deriveSecretKey(seed, 0);
   const publicKey = derivePublicKey(privateKey);
-  const address = deriveAddress(publicKey, { useNanoPrefix: true });
+  const address = deriveAddress(publicKey, { useNanoPrefix: true }) as NanoAddress;
 
   beforeEach(() => {
     nona = new Nona();

--- a/test/unit/services/name-service.test.ts
+++ b/test/unit/services/name-service.test.ts
@@ -1,0 +1,88 @@
+import { NameService } from '../../../lib/services/name/name-service';
+import { Rpc } from '../../../lib/services/rpc/rpc';
+import { NonaParseError } from '../../../lib/shared/errors/parse-error';
+import { NonaUserError } from '../../../lib/shared/errors/user-error';
+import { NanoTarget } from '../../../lib/shared/utils/address';
+
+jest.mock('../../../lib/services/rpc/rpc');
+
+describe('NameService', () => {
+  let nameService: NameService;
+  let rpcMock: jest.Mocked<Rpc>;
+
+  beforeEach(() => {
+    rpcMock = new Rpc({ url: 'http://example.com' }) as jest.Mocked<Rpc>;
+    nameService = new NameService();
+    nameService['rpc'] = rpcMock;
+  });
+
+  it('should initialize properties correctly', () => {
+    expect(nameService['rpc']).toBe(rpcMock);
+  });
+
+  describe('resolveUsername', () => {
+    it('should resolve a valid username', async () => {
+      const username = '@alice';
+      const address = 'nano_1faucet7b6xjyha7m13objpn5ubkquzd6ska8kwopzf1ecbfmn35d1zey3ys';
+
+      rpcMock.call.mockResolvedValue({
+        key: '351B53345493B1F3D05980354C6D41ED32BEFEB2664834B95B7DA06292D9D023',
+      });
+      const resolvedAddress = await nameService.resolveUsername(username);
+      expect(resolvedAddress).toEqual(address);
+      expect(rpcMock.call).toHaveBeenCalledTimes(1);
+      expect(rpcMock.call).toHaveBeenCalledWith('account_key', { account: username });
+    });
+
+    it('should not resolve an invalid username', async () => {
+      const username = '@alice';
+
+      rpcMock.call.mockResolvedValue({
+        error: 500,
+        message: 'Username @alice not registered.',
+      });
+
+      try {
+        await nameService.resolveUsername(username);
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(NonaParseError);
+      }
+    });
+  });
+
+  describe('resolveTarget', () => {
+    it('should not try to resolve a valid nano address', async () => {
+      const target = 'nano_1faucet7b6xjyha7m13objpn5ubkquzd6ska8kwopzf1ecbfmn35d1zey3ys';
+      jest.spyOn(nameService, 'resolveUsername');
+
+      const resolvedAddress = await nameService.resolveTarget(target);
+
+      expect(resolvedAddress).toEqual(target);
+      expect(nameService.resolveUsername).not.toHaveBeenCalled();
+    });
+
+    it('should try resolve an username', async () => {
+      const target = '@alice';
+      const address = 'nano_1faucet7b6xjyha7m13objpn5ubkquzd6ska8kwopzf1ecbfmn35d1zey3ys';
+
+      jest.spyOn(nameService, 'resolveUsername').mockResolvedValue(address);
+
+      const resolvedAddress = await nameService.resolveTarget(target);
+
+      expect(resolvedAddress).toEqual(address);
+      expect(nameService.resolveUsername).toHaveBeenCalledWith(target);
+    });
+
+    it('should fail on invalid target', async () => {
+      const target = 'invalid';
+
+      try {
+        await nameService.resolveTarget(target as NanoTarget);
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(NonaUserError);
+      }
+    });
+  });
+});

--- a/test/unit/services/name-service.test.ts
+++ b/test/unit/services/name-service.test.ts
@@ -12,8 +12,7 @@ describe('NameService', () => {
 
   beforeEach(() => {
     rpcMock = new Rpc({ url: 'http://example.com' }) as jest.Mocked<Rpc>;
-    nameService = new NameService();
-    nameService['rpc'] = rpcMock;
+    nameService = new NameService(rpcMock);
   });
 
   it('should initialize properties correctly', () => {

--- a/test/unit/services/rpc.test.ts
+++ b/test/unit/services/rpc.test.ts
@@ -53,6 +53,18 @@ describe('Rpc', () => {
     await expect(rpc.call(action, body)).rejects.toThrow(error);
   });
 
+  it('should handle RPC name service error', async () => {
+    const action = 'someAction';
+    const body = { param1: 'value1', param2: 'value2' };
+    const message = 'Some error message';
+    const response = { data: { error: 500, message } };
+
+    axiosPostMock.mockResolvedValue(response);
+
+    await expect(rpc.call(action, body)).rejects.toThrow(NonaRpcError);
+    await expect(rpc.call(action, body)).rejects.toThrow(message);
+  });
+
   it('should handle RPC response with unknown data format error', async () => {
     const action = 'someAction';
     const body = { param1: 'value1', param2: 'value2' };

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -1,0 +1,38 @@
+import crypto from 'crypto';
+import { deriveAddress } from 'nanocurrency';
+import { NanoAddress } from '../../lib/shared/utils/address';
+
+/**
+ * Create a simple valid random public key
+ * See: https://docs.nano.org/integration-guides/the-basics/#account-public-key
+ *
+ * @returns a 32 byte value, represented as an uppercase hexadecimal string
+ */
+export const randomPublicKey = (): string => {
+  return crypto.randomBytes(32).toString('hex').toUpperCase();
+};
+
+/**
+ * Creates a valid nano address by generating a random public key with {@link randomPublicKey}
+ *
+ * @param useNanoPrefix - if true, the address will be prefixed with 'nano_'
+ * @returns the nano address
+ */
+export const randomNanoAddress = (useNanoPrefix = true): NanoAddress => {
+  const publicKey = randomPublicKey();
+  // convert it
+  return deriveAddress(publicKey, {
+    useNanoPrefix,
+  }) as NanoAddress;
+};
+
+/**
+ * Creates multiple nano addresses with {@link randomNanoAddress}
+ *
+ * @param length - the number of addresses to generate
+ * @param useNanoPrefix - if true, the addresses will be prefixed with 'nano_'
+ * @returns an array of nano addresses with the specificed length
+ */
+export const randomNanoAddresses = (length: number, useNanoPrefix = true): NanoAddress[] => {
+  return Array.from({ length }, (_v, _i) => randomNanoAddress(useNanoPrefix));
+};


### PR DESCRIPTION
As groundwork to work on the Nano Name Service integration, I first introduced a basic `NanoAddress` type which represents valid Nano address in the form of `nano_.+`. I replaced the references to addresses from `string` to `NanoAddress` which affected more files than I initially expected.

TODO:
- [x] validate addresses in methods (e.g. wallet.send)
- [x] ~stricter validation of addresses~
    - ~currently, any string starting with nano_ is a considered a valid NanoAddress. This could be tightened to check for the length of the string~
    - Commit [#35fb3f6](https://github.com/tgerboui/nona-lib/pull/2/commits/35fb3f618c0b022c0f2163f297d9d60639081a5b) introduces stricter validation of nano_ addresses with help of the nanocurrency library
- [x] fix README.me
    - there are some differences between the interfaces referenced in the README and the actual implementation - for example `ConfirmationFilter` includes `from`, which does not exist in the actual interface.

In the next step I plan to add a `NanoUsername` type to resolve actual usernames - however this is not part of this PR.

Let me know what you think of the changes and also how I should proceed with the TODOs!

Closes #1 