### PR TITLE
Block creation uses invalid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ For more details about websocket, see [Websocket](#websocket).
   - [Expand](#expand)
 - [Key Service](#key-service)
   - [Generate seed](#generate-seed)
-  - [Get secret key](#get-secret-key)
+  - [Get private key](#get-private-key)
   - [Get public key](#get-public-key)
   - [Get address](#get-address)
 - [Node](#node)
@@ -843,16 +843,16 @@ Generates a random seed.
 const seed = await KeyService.generateSeed();
 ```
 
-### Get secret key
+### Get private key
 
 ```typescript
-KeyService.getSecretKey(seed: string, index: number): string
+KeyService.getPrivateKey(seed: string, index: number): string
 ```
 
-Derive a secret key from a seed, given an index.
+Derive a private key from a seed, given an index.
 
 ```typescript
-const privateKey = KeyService.getSecretKey(seed, 0);
+const privateKey = KeyService.getPrivateKey(seed, 0);
 ```
 
 ### Get public key
@@ -861,7 +861,7 @@ const privateKey = KeyService.getSecretKey(seed, 0);
 KeyService.getPublicKey(privateKeyOrAddress: string): string
 ```
 
-Derive a public key from a secret key or an address.
+Derive a public key from a private key or an address.
 
 ```typescript
 const publicKey = KeyService.getPublicKey(privateKey);

--- a/README.md
+++ b/README.md
@@ -740,6 +740,7 @@ You have currently 3 nano in your account.
 const wallet = nona.wallet(privateKey);
 const info = await wallet.info();
 const recipient = 'nano_1send...';
+const recipientPublicKey = KeyService.getPublicKey(recipient);
 
 const sendBlock = await this.blocks.create({
   // Current account 
@@ -753,7 +754,7 @@ const sendBlock = await this.blocks.create({
   // If the block is sending funds, set link to the public key of the destination account.
   // If it is receiving funds, set link to the hash of the block to receive.
   // If the block has no balance change but is updating representative only, set link to 0. 
-  link: recipient,
+  link: recipientPublicKey,
   // Private key of the account 
   key: privateKey,
 });
@@ -857,10 +858,10 @@ const privateKey = KeyService.getSecretKey(seed, 0);
 ### Get public key
 
 ```typescript
-KeyService.getPublicKey(privateKey: string): string
+KeyService.getPublicKey(privateKeyOrAddress: string): string
 ```
 
-Derive a public key from a secret key.
+Derive a public key from a secret key or an address.
 
 ```typescript
 const publicKey = KeyService.getPublicKey(privateKey);

--- a/lib/modules/key/key.ts
+++ b/lib/modules/key/key.ts
@@ -14,7 +14,7 @@ export class Key {
       generativeSeed = await KeyService.generateSeed();
     }
 
-    const privateKey = KeyService.getSecretKey(generativeSeed, 0);
+    const privateKey = KeyService.getPrivateKey(generativeSeed, 0);
     const publicKey = KeyService.getPublicKey(privateKey);
     const address = KeyService.getAddress(publicKey);
 

--- a/lib/modules/wallet/wallet.ts
+++ b/lib/modules/wallet/wallet.ts
@@ -138,6 +138,7 @@ export class Wallet extends Account {
       throw new NonaUserError('Insufficient balance');
     }
     const finalBalance = balance.minus(rawAmount);
+    const receiverPublicKey = KeyService.getPublicKey(address);
 
     // TODO: Maybe set create block in a function in this class
     const block = await this.blocks.create({
@@ -145,7 +146,7 @@ export class Wallet extends Account {
       previous: info.frontier,
       representative: info.representative,
       balance: finalBalance.toString(),
-      link: address,
+      link: receiverPublicKey,
       key: this.privateKey,
     });
 

--- a/lib/services/hash/key-service.ts
+++ b/lib/services/hash/key-service.ts
@@ -24,7 +24,7 @@ export class KeyService {
   /**
    * Derive a public key from a private key.
    *
-   * @param privateKeyOrAddress - Private key or adress to derive the public key from, in hexadecimal or address format
+   * @param privateKeyOrAddress - Private key or address to derive the public key from, in hexadecimal or address format
    * @returns Public key, in hexadecimal format
    */
   public static getPublicKey(privateKeyOrAddress: string): string {

--- a/lib/services/hash/key-service.ts
+++ b/lib/services/hash/key-service.ts
@@ -24,11 +24,11 @@ export class KeyService {
   /**
    * Derive a public key from a secret key.
    *
-   * @param privateKey - Private key to generate the public key from, in hexadecimal or address format
+   * @param privateKeyOrAddress - Private key or adress to derive the public key from, in hexadecimal or address format
    * @returns Public key, in hexadecimal format
    */
-  public static getPublicKey(privateKey: string): string {
-    return derivePublicKey(privateKey);
+  public static getPublicKey(privateKeyOrAddress: string): string {
+    return derivePublicKey(privateKeyOrAddress);
   }
 
   /**

--- a/lib/services/hash/key-service.ts
+++ b/lib/services/hash/key-service.ts
@@ -11,18 +11,18 @@ export class KeyService {
   }
 
   /**
-   * Derive a secret key from a seed, given an index.
+   * Derive a private key from a seed, given an index.
    *
-   * @param seed - The seed to generate the secret key from, in hexadecimal format
-   * @param index - The index to generate the secret key from
-   * @returns Secret key, in hexadecimal format
+   * @param seed - The seed to generate the private key from, in hexadecimal format
+   * @param index - The index to generate the private key from
+   * @returns Private key, in hexadecimal format
    */
-  public static getSecretKey(seed: string, index: number): string {
+  public static getPrivateKey(seed: string, index: number): string {
     return deriveSecretKey(seed, index);
   }
 
   /**
-   * Derive a public key from a secret key.
+   * Derive a public key from a private key.
    *
    * @param privateKeyOrAddress - Private key or adress to derive the public key from, in hexadecimal or address format
    * @returns Public key, in hexadecimal format

--- a/test/unit/modules/key.test.ts
+++ b/test/unit/modules/key.test.ts
@@ -18,12 +18,12 @@ describe('Key', () => {
       const publicKey = 'publicKey';
       const address = 'address';
 
-      keyServiceMock.getSecretKey.mockReturnValue(privateKey);
+      keyServiceMock.getPrivateKey.mockReturnValue(privateKey);
       keyServiceMock.getPublicKey.mockReturnValue(publicKey);
       keyServiceMock.getAddress.mockReturnValue(address);
 
       const result = await key.create(seed);
-      expect(keyServiceMock.getSecretKey).toHaveBeenCalledWith(seed, 0);
+      expect(keyServiceMock.getPrivateKey).toHaveBeenCalledWith(seed, 0);
       expect(keyServiceMock.getPublicKey).toHaveBeenCalledWith(privateKey);
       expect(keyServiceMock.getAddress).toHaveBeenCalledWith(publicKey);
       expect(result).toEqual({ privateKey, publicKey, address });
@@ -36,13 +36,13 @@ describe('Key', () => {
       const address = 'address';
 
       keyServiceMock.generateSeed.mockResolvedValue(generatedSeed);
-      keyServiceMock.getSecretKey.mockReturnValue(privateKey);
+      keyServiceMock.getPrivateKey.mockReturnValue(privateKey);
       keyServiceMock.getPublicKey.mockReturnValue(publicKey);
       keyServiceMock.getAddress.mockReturnValue(address);
 
       const result = await key.create();
       expect(keyServiceMock.generateSeed).toHaveBeenCalled();
-      expect(keyServiceMock.getSecretKey).toHaveBeenCalledWith(generatedSeed, 0);
+      expect(keyServiceMock.getPrivateKey).toHaveBeenCalledWith(generatedSeed, 0);
       expect(keyServiceMock.getPublicKey).toHaveBeenCalledWith(privateKey);
       expect(keyServiceMock.getAddress).toHaveBeenCalledWith(publicKey);
       expect(result).toEqual({ privateKey, publicKey, address });

--- a/test/unit/modules/wallet.test.ts
+++ b/test/unit/modules/wallet.test.ts
@@ -238,6 +238,7 @@ describe('Wallet class', () => {
       wallet.info = jest.fn().mockResolvedValue(info);
       blocksMock.create.mockResolvedValue({ hash: 'createdSendHash' } as any);
       blocksMock.process.mockResolvedValue('processedSendHash');
+      KeyService.getPublicKey = jest.fn().mockReturnValue('publicKey');
 
       const result = await wallet.send('destinationAddress', '1');
       expect(wallet.info).toHaveBeenCalledWith({
@@ -249,9 +250,10 @@ describe('Wallet class', () => {
         previous: 'frontierHash',
         representative: 'representative',
         balance: '4000000000000000000000000000000', // Adjusted for unit conversion in test setup
-        link: 'destinationAddress',
+        link: 'publicKey',
         key: privateKey,
       });
+      expect(KeyService.getPublicKey).toHaveBeenCalledWith('destinationAddress');
       expect(blocksMock.process).toHaveBeenCalledWith({ hash: 'createdSendHash' }, 'send');
       expect(result).toBe('processedSendHash');
     });

--- a/test/unit/services/key-service.test.ts
+++ b/test/unit/services/key-service.test.ts
@@ -24,13 +24,13 @@ describe('KeyService', () => {
     expect(result).toBe(seed);
   });
 
-  it('should derive a secret key', () => {
+  it('should derive a private key', () => {
     const seed = 'cca6fda2102c958239b2e0f02e688414c23939271b7bcfe0d5014ab246071c12';
     const index = 0;
     const secretKey = 'secretKey123';
     (deriveSecretKey as jest.Mock).mockReturnValue(secretKey);
 
-    const result = KeyService.getSecretKey(seed, index);
+    const result = KeyService.getPrivateKey(seed, index);
 
     expect(deriveSecretKey).toHaveBeenCalledWith(seed, index);
     expect(result).toBe(secretKey);


### PR DESCRIPTION
Use public key as link in the send block.

Also rename `KeyService.getSecretKey` to `KeyService.getPrivateKey`, to avoid confusion about the private key keyword.

Resolve #3 